### PR TITLE
Expose the exception type as an attribute.

### DIFF
--- a/ext/mruby_engine/ext.c
+++ b/ext/mruby_engine/ext.c
@@ -13,6 +13,7 @@ ID me_ext_id_generate;
 ID me_ext_id_instructions;
 ID me_ext_id_memory;
 ID me_ext_id_mul;
+ID me_ext_id_type_eq;
 VALUE me_ext_m_json;
 VALUE me_ext_c_mruby_engine;
 VALUE me_ext_c_iseq;
@@ -334,6 +335,7 @@ void Init_mruby_engine(void) {
   me_ext_id_instructions = rb_intern("instructions");
   me_ext_id_memory = rb_intern("memory");
   me_ext_id_mul = rb_intern("*");
+  me_ext_id_type_eq = rb_intern("type=");
 
   me_ext_m_json = rb_path2class("JSON");
 

--- a/ext/mruby_engine/ext.h
+++ b/ext/mruby_engine/ext.h
@@ -7,6 +7,7 @@ extern ID me_ext_id_guest_backtrace_eq;
 extern ID me_ext_id_generate;
 extern ID me_ext_id_instructions;
 extern ID me_ext_id_memory;
+extern ID me_ext_id_type_eq;
 extern VALUE me_ext_m_json;
 extern VALUE me_ext_c_mruby_engine;
 extern VALUE me_ext_c_iseq;

--- a/ext/mruby_engine/host.c
+++ b/ext/mruby_engine/host.c
@@ -1,10 +1,10 @@
-#include <libunwind.h>
-#include <string.h>
 #include "host.h"
 #include "ext.h"
 #include "platform.h"
+#include <libunwind.h>
 #include <ruby.h>
 #include <ruby/thread.h>
+#include <string.h>
 
 const intptr_t ME_HOST_NIL = Qnil;
 const intptr_t ME_HOST_FALSE = Qfalse;
@@ -47,10 +47,14 @@ me_host_exception_t me_host_quota_already_reached_new(const char *format, ...) {
 }
 
 me_host_exception_t me_host_runtime_error_new(
+  const char *type,
+  size_t type_len,
   const char *message,
   me_host_backtrace_t backtrace)
 {
   VALUE exception = rb_exc_new_cstr(me_ext_e_engine_runtime_error, message);
+  VALUE rtype = rb_utf8_str_new(type, type_len);
+  rb_funcall(exception, me_ext_id_type_eq, 1, rtype);
   rb_funcall(exception, me_ext_id_guest_backtrace_eq, 1, backtrace);
   return exception;
 }

--- a/ext/mruby_engine/host.h
+++ b/ext/mruby_engine/host.h
@@ -16,7 +16,11 @@ me_host_exception_t me_host_argument_error_new(const char *format, ...)
   __attribute__((format(printf, 1, 2)));
 me_host_exception_t me_host_type_error_new(const char *format, ...)
   __attribute__((format(printf, 1, 2)));
-me_host_exception_t me_host_runtime_error_new(const char *message, me_host_backtrace_t backtrace);
+me_host_exception_t me_host_runtime_error_new(
+  const char *type,
+  size_t type_len,
+  const char *message,
+  me_host_backtrace_t backtrace);
 me_host_exception_t me_host_syntax_error_new(
   const char *path, int line, int column, const char *message);
 me_host_exception_t me_host_memory_quota_error_new(

--- a/ext/mruby_engine/mruby_engine.c
+++ b/ext/mruby_engine/mruby_engine.c
@@ -97,9 +97,15 @@ me_host_exception_t me_mruby_engine_get_exception(struct me_mruby_engine *self) 
     me_host_backtrace_push_location(host_backtrace, mrb_string_value_cstr(self->state, &location));
   }
 
+  struct RClass *class = mrb_class(self->state, exception);
+  mrb_value class_name_obj = mrb_obj_as_string(self->state, mrb_obj_value(class));
+  struct RString *class_name = mrb_str_ptr(class_name_obj);
   mrb_value message = mrb_funcall_argv(self->state, exception, self->sym_to_s, 0, NULL);
   me_host_exception_t err = me_host_runtime_error_new(
-    mrb_string_value_cstr(self->state, &message), host_backtrace);
+    RSTR_PTR(class_name),
+    RSTR_LEN(class_name),
+    mrb_string_value_cstr(self->state, &message),
+    host_backtrace);
 
   self->state->exc = NULL;
   return err;

--- a/lib/mruby_engine.rb
+++ b/lib/mruby_engine.rb
@@ -3,7 +3,7 @@ require "mruby_engine/version"
 
 class MRubyEngine
   class EngineRuntimeError < EngineError
-    attr_accessor :guest_backtrace
+    attr_accessor :guest_backtrace, :type
   end
 
   class InstructionSequence


### PR DESCRIPTION
r: @alanly @acaron 

As discussed earlier IRL, having the exception type handy on an attribute allows us to have logging by exception type, &c.