### PR TITLE
Temporarily expose err_no to ruby

### DIFF
--- a/ext/mruby_engine/eval_monitored.c
+++ b/ext/mruby_engine/eval_monitored.c
@@ -166,12 +166,12 @@ void me_mruby_engine_eval(
   } while (!wait_result && !self->eval_state.eval_done_p);
 
   clockid_t cid;
-  if (pthread_getcpuclockid(thread, &cid)) {
-    self->cpu_time_ns = -1;
+  if (err_no = pthread_getcpuclockid(thread, &cid)) {
+    self->cpu_time_ns = err_no * -1; // -(ENOENT = 2 || ESRCH = 3) 
   } else {
     struct timespec ts;
-    if (clock_gettime(cid, &ts)) {
-      self->cpu_time_ns = -1;
+    if (err_no = clock_gettime(cid, &ts)) {
+      self->cpu_time_ns = err_no * -1; // -(EINVAL = 22 || EFAULT == 14)
     } else {
       self->cpu_time_ns = ts.tv_sec * 1000000000 + ts.tv_nsec;
     } 

--- a/ext/mruby_engine/ext.c
+++ b/ext/mruby_engine/ext.c
@@ -290,8 +290,8 @@ static VALUE ext_mruby_engine_stat(VALUE rself) {
     rb_hash_aset(stat, ID2SYM(me_ext_id_ctx_switch_iv), Qnil);
   }
 
-  uint64_t cpu_time = me_mruby_engine_get_cpu_time(self);
-  rb_hash_aset(stat, ID2SYM(me_ext_id_cpu_time), ULONG2NUM(cpu_time));
+  int64_t cpu_time = me_mruby_engine_get_cpu_time(self);
+  rb_hash_aset(stat, ID2SYM(me_ext_id_cpu_time), LONG2NUM(cpu_time));
 
   return stat;
 }

--- a/ext/mruby_engine/mruby_engine.c
+++ b/ext/mruby_engine/mruby_engine.c
@@ -316,7 +316,7 @@ int64_t me_mruby_engine_get_ctx_switches_involuntary(struct me_mruby_engine *sel
   return self->ctx_switches_iv;
 }
 
-uint64_t me_mruby_engine_get_cpu_time(struct me_mruby_engine *self) {
+int64_t me_mruby_engine_get_cpu_time(struct me_mruby_engine *self) {
   return self->cpu_time_ns;
 }
 

--- a/ext/mruby_engine/mruby_engine.h
+++ b/ext/mruby_engine/mruby_engine.h
@@ -63,7 +63,7 @@ uint64_t me_mruby_engine_get_instruction_count(struct me_mruby_engine *self);
 uint64_t me_mruby_engine_get_memory_count(struct me_mruby_engine *self);
 int64_t me_mruby_engine_get_ctx_switches_voluntary(struct me_mruby_engine *self);
 int64_t me_mruby_engine_get_ctx_switches_involuntary(struct me_mruby_engine *self);
-uint64_t me_mruby_engine_get_cpu_time(struct me_mruby_engine *self);
+int64_t me_mruby_engine_get_cpu_time(struct me_mruby_engine *self);
 bool me_mruby_engine_get_quota_exception_raised(struct me_mruby_engine *self);
 struct me_proc *me_mruby_engine_generate_code(
   struct me_mruby_engine *self,

--- a/spec/mruby_engine_spec.rb
+++ b/spec/mruby_engine_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe MRubyEngine do
     it ":cpu_time is non zero after executing some code" do
       skip("Not supported on #{RUBY_PLATFORM}.") unless RUBY_PLATFORM =~ /linux/
       engine.sandbox_eval("addition.rb", "1 + 1")
-      expect(engine.stat[:cpu_time]).to be >= 0
+      expect(engine.stat[:cpu_time]).not_to eq(0)
     end
 
     it ":ctx_switches_v is 0 or larger after executing some code" do


### PR DESCRIPTION
The idea is figure out what causes the spurious failures in monitoring the `cpu_time`