### PR TITLE
Do not malloc when we meant to free

### DIFF
--- a/ext/mruby_engine/mruby_engine.c
+++ b/ext/mruby_engine/mruby_engine.c
@@ -57,8 +57,10 @@ static void *mruby_engine_allocf(struct mrb_state *state, void *block, size_t si
 
   struct me_mruby_engine *engine = data;
 
-  if (size == 0 && block != NULL) {
-    me_memory_pool_free(engine->allocator, block);
+  if (size == 0) {
+    if (block != NULL) {
+      me_memory_pool_free(engine->allocator, block);
+    }
     return NULL;
   }
 


### PR DESCRIPTION
Previously, if we were asked to free (size == 0) a NULL pointer
(we observe mruby trying to do this in our tests) we would try to allocate with size of 0.

Instead we should simply report free success to the caller and do nothing.