### PR TITLE
Fix rubocop url make use of https url in place of plain http

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from:
-  - http://shopify.github.io/ruby-style-guide/rubocop.yml
+  - https://shopify.github.io/ruby-style-guide/rubocop.yml
 
 AllCops:
   TargetRubyVersion: 2.2


### PR DESCRIPTION
ping @EiNSTeiN- @acaron 