### PR TITLE
Add missing require for SecureRandom

### DIFF
--- a/spec/arbitrary.rb
+++ b/spec/arbitrary.rb
@@ -1,5 +1,6 @@
 require "bigdecimal"
 require "bigdecimal/util"
+require "securerandom"
 
 module Arbitrary
   refine Fixnum.singleton_class do


### PR DESCRIPTION
On my host spec test using `SecureRandom` fails without the require.