### PR TITLE
Fix Ruby 3.1.0-dev build

### DIFF
--- a/ext/mruby_engine/extconf.rb
+++ b/ext/mruby_engine/extconf.rb
@@ -14,6 +14,13 @@ unless have_func("rb_thread_call_without_gvl")
   abort("rb_thread_call_without_gvl not found: do you have Ruby >= 2.0?")
 end
 
+if RUBY_VERSION >= '3.1'
+  module MakeMakefile
+    # "Revert" of https://github.com/ruby/ruby/commit/4b6fd8329b46701414aba2eeca10013cf66ec513
+    alias_method :try_header, (config_string('try_header') || :try_cpp)
+  end
+end
+
 unless find_header 'mruby.h', File.expand_path('../mruby/include/', __FILE__)
   abort 'missing mruby.h: did you clone the submodule?'
 end


### PR DESCRIPTION
Since https://github.com/ruby/ruby/commit/4b6fd8329b46701414aba2eeca10013cf66ec513
it include `ruby.h` and since they both define similar names like `RObject` it fails.

This should fix the `ruby-head` build.