### PR TITLE
Add support for m1

### DIFF
--- a/ext/mruby_engine/mruby-mpdecimal/mrbgem.rake
+++ b/ext/mruby_engine/mruby-mpdecimal/mrbgem.rake
@@ -6,6 +6,7 @@ MRuby::Gem::Specification.new('mruby-mpdecimal') do |spec|
 
   spec.cc do
     cc.flags += %w(-Wno-declaration-after-statement)
-    cc.defines += %w(CONFIG_64 ASM HAVE_UINT128_T)
+    cc.defines += %w(CONFIG_64 HAVE_UINT128_T)
+    cc.defines += RUBY_PLATFORM =~ /x86/i ? %w(ASM) : %w(ANSI)
   end
 end


### PR DESCRIPTION
This is the repo that core uses for the mruby_engine gem.