### PR TITLE
Make the spec arm compatible

### DIFF
--- a/spec/mruby_engine_spec.rb
+++ b/spec/mruby_engine_spec.rb
@@ -44,10 +44,7 @@ RSpec.describe MRubyEngine do
     it "refuses to allocate ludicrously small amount of memory" do
       expect {
         MRubyEngine.new(8, reasonable_instruction_quota, reasonable_time_quota)
-      }.to raise_error(ArgumentError, squish(<<-MESSAGE))
-        memory pool must be between 256KiB and 262144KiB (requested 8B rounded
-        to 4KiB)
-      MESSAGE
+      }.to raise_error(ArgumentError, /^memory pool must be between 256KiB and 262144KiB/)
     end
   end
 


### PR DESCRIPTION
Follow-up to #48.
M1 machines round the requested memory differently. This is irrelevant.