### PR TITLE
Upgrade mruby submodule from 1.2 to 4.0

### DIFF
--- a/ext/mruby_engine/flag_helper.rb
+++ b/ext/mruby_engine/flag_helper.rb
@@ -22,7 +22,6 @@ module Flags
         MRB_INT64
         MRB_UTF8_STRING
         MRB_WORD_BOXING
-        YYDEBUG
       )
       defines << "_GNU_SOURCE" if RUBY_PLATFORM =~ /linux/
       defines

--- a/ext/mruby_engine/mruby-mpdecimal/src/ext.c
+++ b/ext/mruby_engine/mruby-mpdecimal/src/ext.c
@@ -267,11 +267,11 @@ void mrb_mruby_mpdecimal_gem_init(mrb_state *state) {
   struct RClass *c_decimal = mrb_define_class(state, "Decimal", state->object_class);
   MRB_SET_INSTANCE_TT(c_decimal, MRB_TT_DATA);
 
-  mrb_define_method_raw(
-    state,
-    c_decimal,
-    mrb_intern_cstr(state, "initialize"),
-    mrb_proc_new_cfunc_with_env(state, ext_decimal_initialize, 1, &context));
+  {
+    mrb_method_t m;
+    MRB_METHOD_FROM_PROC(m, mrb_proc_new_cfunc_with_env(state, ext_decimal_initialize, 1, &context));
+    mrb_define_method_raw(state, c_decimal, mrb_intern_cstr(state, "initialize"), m);
+  }
   mrb_define_method(state, c_decimal, "+", ext_decimal_add, MRB_ARGS_REQ(1));
   mrb_define_method(state, c_decimal, "-", ext_decimal_sub, MRB_ARGS_REQ(1));
   mrb_define_method(state, c_decimal, "*", ext_decimal_mul, MRB_ARGS_REQ(1));

--- a/ext/mruby_engine/mruby_config.rb
+++ b/ext/mruby_engine/mruby_config.rb
@@ -24,8 +24,6 @@ MRuby::Build.new do |conf|
   conf.gem core: 'mruby-bin-mirb'
   conf.gem core: 'mruby-bin-mruby'
 
-  conf.bins = ['mrbc', 'mruby']
-
   conf.cc do |cc|
     cc.flags += %w(-fPIC)
     cc.flags += Flags.cflags
@@ -44,8 +42,6 @@ MRuby::CrossBuild.new('sandbox') do |conf|
   enable_debug
 
   conf.gembox mruby_engine_gembox_path
-
-  conf.bins = []
 
   conf.cc do |cc|
     cc.flags += %w(-fPIC)

--- a/spec/mruby_engine_spec.rb
+++ b/spec/mruby_engine_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe MRubyEngine do
   it "raises on a syntax error" do
     expect {
       engine.sandbox_eval("syntax_error.rb", "(")
-    }.to raise_error(MRubyEngine::EngineSyntaxError, "syntax_error.rb:1:1: syntax error")
+    }.to raise_error(MRubyEngine::EngineSyntaxError, /syntax_error\.rb:1:1: syntax error/)
   end
 
   it "raises if script raised an error" do
@@ -524,7 +524,7 @@ RSpec.describe MRubyEngine do
     it "reports syntax errors" do
       expect do
         MRubyEngine::InstructionSequence.new([["sample.rb", "("]])
-      end.to raise_error(MRubyEngine::EngineSyntaxError, "sample.rb:1:1: syntax error")
+      end.to raise_error(MRubyEngine::EngineSyntaxError, /sample\.rb:1:1: syntax error/)
     end
 
     it "reports syntax error with multiple files" do
@@ -532,7 +532,7 @@ RSpec.describe MRubyEngine do
         MRubyEngine::InstructionSequence.new(
           [["sample.rb", "a = 1"], ["sample_2.rb", "("]],
         )
-      end.to raise_error(MRubyEngine::EngineSyntaxError, "sample_2.rb:1:1: syntax error")
+      end.to raise_error(MRubyEngine::EngineSyntaxError, /sample_2\.rb:1:1: syntax error/)
     end
   end
 end


### PR DESCRIPTION
I recognize you may be letting this gem go — Shopify Scripts sunset June 30. If you are, feel free to close. If anyone wants these changes, here they are.

Motivation
---
mruby 4.0 brings Prism as the default compiler, giving syntax parity with modern Ruby.

Fixes required for 4.0 compatibility
---
- `conf.bins` in mruby_config.rb: 4.0's presym task propagates the bins list into the mrbc sub-build, where the mruby binary doesn't exist.
- `YYDEBUG` in flag_helper.rb and `mrb_define_method_raw` signature in mruby-mpdecimal: API changes in 4.0.
- Three spec assertions loosened to regex match: 4.0 parser appends detail to syntax error messages, same pattern as CRuby parser upgrades.