### PR TITLE
Use corresponding me_host_free for iseq/data to match me_host_malloc

### DIFF
--- a/ext/mruby_engine/mruby_engine.c
+++ b/ext/mruby_engine/mruby_engine.c
@@ -417,8 +417,8 @@ struct me_iseq *me_iseq_new(
 }
 
 void me_iseq_destroy(struct me_iseq *iseq) {
-  free(iseq->data);
-  free(iseq);
+  me_host_free(iseq->data);
+  me_host_free(iseq);
 }
 
 size_t me_iseq_size(struct me_iseq *iseq) {


### PR DESCRIPTION
https://github.com/Shopify/mruby-engine/blob/db03e6b14b879f821e9691c7e89267080480397c/ext/mruby_engine/host.c#L16-L23